### PR TITLE
Feature/upgrade infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,9 @@ logs
 **/*.back.*
 
 node_modules
+
+# Local env backups
+.env.backup
 bower_components
 
 *.sublime*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: help build-frontend build-backend deploy-frontend deploy-backend up down logs
+
+help:
+	@echo "Available targets:"
+	@echo "  build-frontend   Build only the frontend (nginx) image"
+	@echo "  build-backend    Build only the backend image"
+	@echo "  deploy-frontend  Up only nginx (no-deps) [BUILD=1 to build]"
+	@echo "  deploy-backend   Up only backend (no-deps) [BUILD=1 to build]"
+	@echo "  up               docker compose up -d (all)"
+	@echo "  down             docker compose down"
+	@echo "  logs             docker compose logs -f"
+
+build-frontend:
+	./scripts/build-frontend.sh
+
+build-backend:
+	./scripts/build-backend.sh
+
+deploy-frontend:
+	BUILD=$(BUILD) ./scripts/deploy-frontend.sh
+
+deploy-backend:
+	BUILD=$(BUILD) ./scripts/deploy-backend.sh
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: help build-frontend build-backend deploy-frontend deploy-backend up down logs
+.PHONY: help build-frontend build-backend deploy-frontend deploy-backend up down logs \
+	deploy-heroku-backend deploy-heroku-frontend
 
 help:
 	@echo "Available targets:"
@@ -9,6 +10,8 @@ help:
 	@echo "  up               docker compose up -d (all)"
 	@echo "  down             docker compose down"
 	@echo "  logs             docker compose logs -f"
+	@echo "  deploy-heroku-backend  Deploy backend (Docker) para Heroku (usa HEROKU_BACKEND_APP)"
+	@echo "  deploy-heroku-frontend Deploy frontend (Docker) para Heroku (usa HEROKU_FRONTEND_APP)"
 
 build-frontend:
 	./scripts/build-frontend.sh
@@ -31,3 +34,8 @@ down:
 logs:
 	docker compose logs -f
 
+deploy-heroku-backend:
+	./scripts/heroku-deploy-backend.sh
+
+deploy-heroku-frontend:
+	./scripts/heroku-deploy-frontend.sh

--- a/README.md
+++ b/README.md
@@ -105,3 +105,26 @@ Se quiser acessar usando os hostnames configurados no Nginx local (porta 82):
   - Admin: `http://admin.compilerhub.store:82`
 
 Observação: a API retorna paths relativos para imagens (`/media/...`) e o frontend monta a URL final usando `VITE_API_URL`. Por isso é essencial definir `VITE_API_URL` com o host/porta corretos (incluindo `:82`).
+
+## Deploy isolado (frontend e backend)
+
+Para simplificar releases independentes, este repositório agora possui scripts e targets que permitem publicar apenas o frontend (nginx) ou apenas o backend, sem reiniciar os demais serviços.
+
+- Pré‑requisito: `docker compose` e um `.env` válido na raiz.
+
+- Build isolado:
+  - `make build-frontend` (imagem do nginx que serve o bundle do Vite)
+  - `make build-backend` (imagem do Django + Gunicorn)
+
+- Deploy isolado (sem rebuild):
+  - `make deploy-frontend` (sobe/aplica somente `nginx` com `--no-deps`)
+  - `make deploy-backend` (sobe/aplica somente `backend` com `--no-deps`)
+
+- Deploy isolado com build no mesmo passo:
+  - `BUILD=1 make deploy-frontend`
+  - `BUILD=1 make deploy-backend`
+
+Notas:
+- O backend já executa migrações e `collectstatic` no entrypoint ao subir o container.
+- O serviço `nginx` serve o frontend estático e expõe as rotas de API/Admin (conforme `nginx/nginx.conf`). Se necessário, você pode publicar apenas o `backend` (ex.: hotfix) sem tocar no `nginx`.
+- Para publicar ambos como antes: `docker compose up -d --build`.

--- a/README.md
+++ b/README.md
@@ -128,3 +128,37 @@ Notas:
 - O backend já executa migrações e `collectstatic` no entrypoint ao subir o container.
 - O serviço `nginx` serve o frontend estático e expõe as rotas de API/Admin (conforme `nginx/nginx.conf`). Se necessário, você pode publicar apenas o `backend` (ex.: hotfix) sem tocar no `nginx`.
 - Para publicar ambos como antes: `docker compose up -d --build`.
+
+## Deploy em PaaS (Render/Heroku)
+
+Este repo já está preparado para deploys em PaaS com serviços separados.
+
+### Render.com
+
+- Arquivo: `render.yaml` na raiz define dois serviços:
+  - `rosana-backend` (Web Service via Dockerfile `backend/Dockerfile`).
+  - `rosana-frontend` (Static Site buildando `frontend/` e publicando `dist/`).
+- Backend:
+  - Ajuste as variáveis sensíveis no dashboard do Render (as chaves com `sync: false`).
+  - Opcional: aumente o disco `media` caso use uploads.
+- Frontend:
+  - Defina `VITE_API_URL` apontando para a URL do backend Render.
+  - Faça o primeiro deploy via “New +” → “Blueprint” apontando para o repo.
+
+### Heroku (Container Registry)
+
+- Pré‑requisitos: Heroku CLI logado (`heroku login`) e apps criados:
+  - Um app para o backend (ex.: `rosana-backend`)
+  - Um app para o frontend (ex.: `rosana-frontend`)
+- Backend (usa `backend/Dockerfile` e respeita `$PORT`):
+  - `HEROKU_BACKEND_APP=rosana-backend make deploy-heroku-backend`
+- Frontend (usa `frontend/Dockerfile` com Nginx ouvindo `$PORT`):
+  - `HEROKU_FRONTEND_APP=rosana-frontend make deploy-heroku-frontend`
+- Variáveis:
+  - Configure as envs no Heroku Dashboard (mesmo conjunto do `.env`, evitando `VITE_` com segredos).
+  - No frontend, ajuste `VITE_API_URL` para a URL pública do backend.
+
+Notas gerais
+- Backend agora lê a porta do ambiente (`$PORT`), necessário em PaaS.
+- Frontend Nginx também usa `$PORT` via template; localmente segue na porta 80 (mapeada pelo Compose).
+- O Compose com `nginx` continua válido para produção self‑hosted; Render/Heroku usam os serviços desacoplados.

--- a/backend/scripts/entrypoint.sh
+++ b/backend/scripts/entrypoint.sh
@@ -34,4 +34,6 @@ EOF
 # 'exec' é importante pois substitui o processo do script pelo do Gunicorn,
 # tornando o Gunicorn o processo principal (PID 1) do contêiner.
 echo "Iniciando Gunicorn..."
-exec gunicorn --bind 0.0.0.0:8000 backend.wsgi:application
+# Respeita a porta definida pelo provedor (Heroku/Render) ou usa 8000 por padrão
+PORT="${PORT:-8000}"
+exec gunicorn --bind 0.0.0.0:${PORT} backend.wsgi:application

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,9 +18,16 @@ RUN npm run build
 
 FROM nginx:1.29.1-alpine
 
+# Copia os artefatos estáticos do build
 COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Template de config para suportar $PORT (Heroku/Render) mantendo 80 como default
+COPY nginx-heroku.conf.template /etc/nginx/conf.d/default.conf.template
+
+# Entrypoint: aplica envsubst no template para usar $PORT, caindo para 80 se não definido
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
-
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+# Gera config do Nginx com a PORT indicada pelo provedor (fallback: 80)
+echo "[nginx] rendering config with PORT=${PORT:-80}"
+envsubst '\n$PORT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+
+exec nginx -g 'daemon off;'
+

--- a/frontend/nginx-heroku.conf.template
+++ b/frontend/nginx-heroku.conf.template
@@ -1,0 +1,11 @@
+server {
+    listen ${PORT:-80};
+    server_name _;
+
+    root /usr/share/nginx/html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+}
+

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,55 @@
+# Render.com multi-service configuration
+
+services:
+  # Backend (Django + Gunicorn) via Dockerfile
+  - type: web
+    name: rosana-backend
+    env: docker
+    dockerfilePath: backend/Dockerfile
+    autoDeploy: true
+    plan: starter
+    region: oregon
+    healthCheckPath: /admin/login/
+    numInstances: 1
+    # Render will route to the container's exposed port; backend honors $PORT.
+    disk:
+      name: media
+      mountPath: /usr/src/app/media
+      sizeGB: 1
+    envVars:
+      - key: DEBUG
+        value: "False"
+      - key: DJANGO_SUPERUSER_USERNAME
+        sync: false
+      - key: DJANGO_SUPERUSER_EMAIL
+        sync: false
+      - key: DJANGO_SUPERUSER_PASSWORD
+        sync: false
+      - key: SECRET_KEY
+        sync: false
+      - key: API_KEY
+        sync: false
+      - key: POSTGRES_DB
+        sync: false
+      - key: POSTGRES_USER
+        sync: false
+      - key: POSTGRES_PASSWORD
+        sync: false
+      - key: POSTGRES_HOST
+        sync: false
+      - key: POSTGRES_PORT
+        value: "5432"
+
+  # Frontend as Static Site (cheaper, CDN)
+  - type: static
+    name: rosana-frontend
+    rootDir: frontend
+    buildCommand: npm ci && npm run build
+    staticPublishPath: dist
+    autoDeploy: true
+    envVars:
+      - key: VITE_API_URL
+        sync: false
+      - key: VITE_API_KEY
+        sync: false
+

--- a/scripts/build-backend.sh
+++ b/scripts/build-backend.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+# Build only the backend image
+echo "[build-backend] Building backend image..."
+docker compose build backend
+
+echo "[build-backend] Done."
+

--- a/scripts/build-frontend.sh
+++ b/scripts/build-frontend.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+# Build only the frontend (nginx) image
+echo "[build-frontend] Building nginx (frontend) image..."
+docker compose build nginx
+
+echo "[build-frontend] Done."
+

--- a/scripts/deploy-backend.sh
+++ b/scripts/deploy-backend.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+# Optionally build first if requested
+if [ "${BUILD:-}" = "1" ]; then
+  echo "[deploy-backend] BUILD=1 -> building backend image..."
+  docker compose build backend
+fi
+
+echo "[deploy-backend] Deploying backend without touching nginx..."
+docker compose up -d --no-deps backend
+
+echo "[deploy-backend] Deployed backend."
+

--- a/scripts/deploy-frontend.sh
+++ b/scripts/deploy-frontend.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+# Optionally build first if requested
+if [ "${BUILD:-}" = "1" ]; then
+  echo "[deploy-frontend] BUILD=1 -> building nginx (frontend) image..."
+  docker compose build nginx
+fi
+
+echo "[deploy-frontend] Deploying frontend (nginx) without touching backend..."
+docker compose up -d --no-deps nginx
+
+echo "[deploy-frontend] Deployed nginx."
+

--- a/scripts/heroku-deploy-backend.sh
+++ b/scripts/heroku-deploy-backend.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+if ! command -v heroku >/dev/null 2>&1; then
+  echo "Heroku CLI não encontrado. Instale em: https://devcenter.heroku.com/articles/heroku-cli" >&2
+  exit 1
+fi
+
+: "${HEROKU_BACKEND_APP:?Defina HEROKU_BACKEND_APP com o nome do app do backend}"
+
+echo "[heroku] Login no Container Registry..."
+heroku container:login
+
+echo "[heroku] Push da imagem do backend..."
+heroku container:push web -a "$HEROKU_BACKEND_APP" -f backend/Dockerfile
+
+echo "[heroku] Release da imagem..."
+heroku container:release web -a "$HEROKU_BACKEND_APP"
+
+echo "[heroku] Feito. App: https://$HEROKU_BACKEND_APP.herokuapp.com"
+

--- a/scripts/heroku-deploy-frontend.sh
+++ b/scripts/heroku-deploy-frontend.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+set -euo pipefail
+
+if ! command -v heroku >/dev/null 2>&1; then
+  echo "Heroku CLI não encontrado. Instale em: https://devcenter.heroku.com/articles/heroku-cli" >&2
+  exit 1
+fi
+
+: "${HEROKU_FRONTEND_APP:?Defina HEROKU_FRONTEND_APP com o nome do app do frontend}"
+
+echo "[heroku] Login no Container Registry..."
+heroku container:login
+
+echo "[heroku] Push da imagem do frontend (Nginx)..."
+heroku container:push web -a "$HEROKU_FRONTEND_APP" -f frontend/Dockerfile
+
+echo "[heroku] Release da imagem..."
+heroku container:release web -a "$HEROKU_FRONTEND_APP"
+
+echo "[heroku] Feito. App: https://$HEROKU_FRONTEND_APP.herokuapp.com"
+


### PR DESCRIPTION
- Separa deploy de frontend (nginx estático) e backend (Django).
 - Scripts/targets: make build-*, make deploy-*, Heroku deploys, render.yaml.
      - Backend e Nginx respeitam $PORT para PaaS.
      - README atualizado com passo a passo de Render/Heroku.
      - Testado localmente com Docker Compose; branch pronta para validação.
